### PR TITLE
Use macOS Keychain for private key passphrase

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ build: get
 	${GO} get -u github.com/ssh-vault/crypto
 	${GO} get -u github.com/ssh-vault/crypto/aead
 	${GO} get -u github.com/ssh-vault/crypto/oaep
+	${GO} get -u github.com/keybase/go-keychain
 	${GO} build -ldflags "-X main.version=${VERSION}" -o ${BIN_NAME} cmd/ssh-vault/main.go;
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ build: get
 	${GO} get -u github.com/ssh-vault/crypto/aead
 	${GO} get -u github.com/ssh-vault/crypto/oaep
 	${GO} get -u github.com/keybase/go-keychain
+	${GO} get -u github.com/kr/pty
 	${GO} build -ldflags "-X main.version=${VERSION}" -o ${BIN_NAME} cmd/ssh-vault/main.go;
 
 clean:

--- a/get_password.go
+++ b/get_password.go
@@ -1,0 +1,10 @@
+// +build !darwin
+
+// For platforms without managed ssh private key passwords,
+// fallback to prompting the user.
+
+package sshvault
+
+func (v *vault) GetPassword() ([]byte, error) {
+	return v.GetPasswordPrompt()
+}

--- a/get_password_darwin.go
+++ b/get_password_darwin.go
@@ -12,27 +12,27 @@ import (
 	"fmt"
 	"path/filepath"
 
-  "github.com/keybase/go-keychain"
+	"github.com/keybase/go-keychain"
 )
 
 func (v *vault) GetPassword() ([]byte, error) {
-  var keyPassword []byte
+	var keyPassword []byte
 
-  key_path, err := filepath.Abs(v.key)
-  if err != nil {
-    return nil, fmt.Errorf("Error finding private key: %s", err)
-  }
+	key_path, err := filepath.Abs(v.key)
+	if err != nil {
+		return nil, fmt.Errorf("Error finding private key: %s", err)
+	}
 
-  keyPassword, err = keychain.GetGenericPassword("SSH", key_path, "", "")
-  if err == nil {
-    return keyPassword, nil
-  }
+	keyPassword, err = keychain.GetGenericPassword("SSH", key_path, "", "")
+	if err == nil {
+		return keyPassword, nil
+	}
 
-  // Darn, Keychain doesn't have the password for that file. Prompt the user.
-  keyPassword, err = v.GetPasswordPrompt()
-  if err != nil {
-    return nil, err
-  }
+	// Darn, Keychain doesn't have the password for that file. Prompt the user.
+	keyPassword, err = v.GetPasswordPrompt()
+	if err != nil {
+		return nil, err
+	}
 
-  return keyPassword, nil
+	return keyPassword, nil
 }

--- a/get_password_darwin.go
+++ b/get_password_darwin.go
@@ -1,0 +1,38 @@
+// +build darwin
+
+// Apple's OpenSSH fork uses Keychain for private key passphrases.
+// They're indexed by the absolute file path to the private key,
+// e.g. ~/.ssh/id_rsa
+//
+// If the passphrase isn't in keychain, prompt the user.
+
+package sshvault
+
+import (
+	"fmt"
+	"path/filepath"
+
+  "github.com/keybase/go-keychain"
+)
+
+func (v *vault) GetPassword() ([]byte, error) {
+  var keyPassword []byte
+
+  key_path, err := filepath.Abs(v.key)
+  if err != nil {
+    return nil, fmt.Errorf("Error finding private key: %s", err)
+  }
+
+  keyPassword, err = keychain.GetGenericPassword("SSH", key_path, "", "")
+  if err == nil {
+    return keyPassword, nil
+  }
+
+  // Darn, Keychain doesn't have the password for that file. Prompt the user.
+  keyPassword, err = v.GetPasswordPrompt()
+  if err != nil {
+    return nil, err
+  }
+
+  return keyPassword, nil
+}

--- a/get_password_darwin_test.go
+++ b/get_password_darwin_test.go
@@ -1,0 +1,97 @@
+// +build darwin
+
+package sshvault
+
+import (
+  "fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+  "strings"
+  "syscall"
+	"testing"
+
+  "github.com/kr/pty"
+  "github.com/keybase/go-keychain"
+)
+
+func InjectKeychainPassword(path, pw string) (error) {
+	item := keychain.NewItem()
+	item.SetSecClass(keychain.SecClassGenericPassword)
+  item.SetLabel(fmt.Sprintf("SSH: %s", path))
+	item.SetService("SSH")
+	item.SetAccount(path)
+	item.SetData([]byte(pw))
+	item.SetSynchronizable(keychain.SynchronizableNo)
+
+	return keychain.AddItem(item)
+}
+
+func DeleteKeychainPassword(path string) (error) {
+	item := keychain.NewItem()
+	item.SetSecClass(keychain.SecClassGenericPassword)
+	item.SetService("SSH")
+	item.SetAccount(path)
+
+	return keychain.DeleteItem(item)
+}
+
+func TestKeychain(t *testing.T) {
+  key_pw := "argle-bargle"
+  key_bad_pw := "totally-bogus\n"
+
+  dir, err := ioutil.TempDir("", "vault")
+	if err != nil {
+		t.Error(err)
+	}
+	defer os.RemoveAll(dir) // clean up
+
+	tmpfile := filepath.Join(dir, "vault")
+
+	vault, err := New("test_data/id_rsa.pub", "", "create", tmpfile)
+	if err != nil {
+		t.Error(err)
+	}
+  key_path, err := filepath.Abs(vault.key)
+  if err != nil {
+    t.Errorf("Error finding private key: %s", err)
+  }
+  err = InjectKeychainPassword(key_path, key_pw)
+  if err != nil {
+    t.Errorf("Error setting up keychain for testing: %s", err)
+  }
+  defer DeleteKeychainPassword(key_path) // clean up
+
+  _, tty, err := pty.Open()
+  if err != nil {
+    t.Errorf("Unable to open pty: %s", err)
+  }
+
+  // File Descriptor magic. GetPasswordPrompt() reads the password
+  // from stdin. For the test, we save stdin to a spare FD,
+  // point stdin at the file, run the system under test, and
+  // finally restore the original stdin
+  old_stdin, _ := syscall.Dup(int(syscall.Stdin))
+  old_stdout, _ := syscall.Dup(int(syscall.Stdout))
+  syscall.Dup2(int(tty.Fd()), int(syscall.Stdin))
+  syscall.Dup2(int(tty.Fd()), int(syscall.Stdout))
+
+  go PtyWriteback(pty, key_bad_pw)
+
+  key_pw_test, err := vault.GetPassword()
+
+  syscall.Dup2(old_stdin,  int(syscall.Stdin))
+  syscall.Dup2(old_stdout, int(syscall.Stdout))
+
+  if err != nil {
+    t.Error(err)
+  }
+  if strings.Trim(string(key_pw_test), "\n") == strings.Trim(key_bad_pw, "\n") {
+    t.Errorf("PTY-based password prompt used, not keychain!")
+  }
+
+  if strings.Trim(string(key_pw_test), "\n") != strings.Trim(key_pw, "\n") {
+    t.Errorf("keychain error: %s expected %s, got %s\n", key_path, key_pw, key_pw_test)
+  }
+
+}

--- a/get_password_darwin_test.go
+++ b/get_password_darwin_test.go
@@ -3,22 +3,22 @@
 package sshvault
 
 import (
-  "fmt"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
-  "strings"
-  "syscall"
+	"strings"
+	"syscall"
 	"testing"
 
-  "github.com/kr/pty"
-  "github.com/keybase/go-keychain"
+	"github.com/keybase/go-keychain"
+	"github.com/kr/pty"
 )
 
-func InjectKeychainPassword(path, pw string) (error) {
+func InjectKeychainPassword(path, pw string) error {
 	item := keychain.NewItem()
 	item.SetSecClass(keychain.SecClassGenericPassword)
-  item.SetLabel(fmt.Sprintf("SSH: %s", path))
+	item.SetLabel(fmt.Sprintf("SSH: %s", path))
 	item.SetService("SSH")
 	item.SetAccount(path)
 	item.SetData([]byte(pw))
@@ -27,7 +27,7 @@ func InjectKeychainPassword(path, pw string) (error) {
 	return keychain.AddItem(item)
 }
 
-func DeleteKeychainPassword(path string) (error) {
+func DeleteKeychainPassword(path string) error {
 	item := keychain.NewItem()
 	item.SetSecClass(keychain.SecClassGenericPassword)
 	item.SetService("SSH")
@@ -37,10 +37,10 @@ func DeleteKeychainPassword(path string) (error) {
 }
 
 func TestKeychain(t *testing.T) {
-  key_pw := "argle-bargle"
-  key_bad_pw := "totally-bogus\n"
+	key_pw := "argle-bargle"
+	key_bad_pw := "totally-bogus\n"
 
-  dir, err := ioutil.TempDir("", "vault")
+	dir, err := ioutil.TempDir("", "vault")
 	if err != nil {
 		t.Error(err)
 	}
@@ -52,46 +52,46 @@ func TestKeychain(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-  key_path, err := filepath.Abs(vault.key)
-  if err != nil {
-    t.Errorf("Error finding private key: %s", err)
-  }
-  err = InjectKeychainPassword(key_path, key_pw)
-  if err != nil {
-    t.Errorf("Error setting up keychain for testing: %s", err)
-  }
-  defer DeleteKeychainPassword(key_path) // clean up
+	key_path, err := filepath.Abs(vault.key)
+	if err != nil {
+		t.Errorf("Error finding private key: %s", err)
+	}
+	err = InjectKeychainPassword(key_path, key_pw)
+	if err != nil {
+		t.Errorf("Error setting up keychain for testing: %s", err)
+	}
+	defer DeleteKeychainPassword(key_path) // clean up
 
-  _, tty, err := pty.Open()
-  if err != nil {
-    t.Errorf("Unable to open pty: %s", err)
-  }
+	_, tty, err := pty.Open()
+	if err != nil {
+		t.Errorf("Unable to open pty: %s", err)
+	}
 
-  // File Descriptor magic. GetPasswordPrompt() reads the password
-  // from stdin. For the test, we save stdin to a spare FD,
-  // point stdin at the file, run the system under test, and
-  // finally restore the original stdin
-  old_stdin, _ := syscall.Dup(int(syscall.Stdin))
-  old_stdout, _ := syscall.Dup(int(syscall.Stdout))
-  syscall.Dup2(int(tty.Fd()), int(syscall.Stdin))
-  syscall.Dup2(int(tty.Fd()), int(syscall.Stdout))
+	// File Descriptor magic. GetPasswordPrompt() reads the password
+	// from stdin. For the test, we save stdin to a spare FD,
+	// point stdin at the file, run the system under test, and
+	// finally restore the original stdin
+	old_stdin, _ := syscall.Dup(int(syscall.Stdin))
+	old_stdout, _ := syscall.Dup(int(syscall.Stdout))
+	syscall.Dup2(int(tty.Fd()), int(syscall.Stdin))
+	syscall.Dup2(int(tty.Fd()), int(syscall.Stdout))
 
-  go PtyWriteback(pty, key_bad_pw)
+	go PtyWriteback(pty, key_bad_pw)
 
-  key_pw_test, err := vault.GetPassword()
+	key_pw_test, err := vault.GetPassword()
 
-  syscall.Dup2(old_stdin,  int(syscall.Stdin))
-  syscall.Dup2(old_stdout, int(syscall.Stdout))
+	syscall.Dup2(old_stdin, int(syscall.Stdin))
+	syscall.Dup2(old_stdout, int(syscall.Stdout))
 
-  if err != nil {
-    t.Error(err)
-  }
-  if strings.Trim(string(key_pw_test), "\n") == strings.Trim(key_bad_pw, "\n") {
-    t.Errorf("PTY-based password prompt used, not keychain!")
-  }
+	if err != nil {
+		t.Error(err)
+	}
+	if strings.Trim(string(key_pw_test), "\n") == strings.Trim(key_bad_pw, "\n") {
+		t.Errorf("PTY-based password prompt used, not keychain!")
+	}
 
-  if strings.Trim(string(key_pw_test), "\n") != strings.Trim(key_pw, "\n") {
-    t.Errorf("keychain error: %s expected %s, got %s\n", key_path, key_pw, key_pw_test)
-  }
+	if strings.Trim(string(key_pw_test), "\n") != strings.Trim(key_pw, "\n") {
+		t.Errorf("keychain error: %s expected %s, got %s\n", key_path, key_pw, key_pw_test)
+	}
 
 }

--- a/get_password_prompt.go
+++ b/get_password_prompt.go
@@ -1,0 +1,18 @@
+package sshvault
+
+import (
+	"fmt"
+	"syscall"
+
+	"golang.org/x/crypto/ssh/terminal"
+)
+
+func (v *vault) GetPasswordPrompt() ([]byte, error) {
+	fmt.Printf("Enter key password (%s): ", v.key)
+	keyPassword, err := terminal.ReadPassword(int(syscall.Stdin))
+	if err != nil {
+		return nil, err
+	}
+
+	return keyPassword, nil
+}

--- a/vault_test.go
+++ b/vault_test.go
@@ -52,13 +52,16 @@ func TestVaultFunctions(t *testing.T) {
 	// point stdin at the file, run the system under test, and
 	// finally restore the original stdin
 	old_stdin, _ := syscall.Dup(int(syscall.Stdin))
+	old_stdout, _ := syscall.Dup(int(syscall.Stdout))
 	syscall.Dup2(int(tty.Fd()), int(syscall.Stdin))
+	syscall.Dup2(int(tty.Fd()), int(syscall.Stdout))
 
 	go PtyWriteback(pty, key_pw)
 
 	key_pw_test, err := vault.GetPasswordPrompt()
 
-	syscall.Dup2(old_stdin, int(syscall.Stdin))
+	syscall.Dup2(old_stdin,  int(syscall.Stdin))
+	syscall.Dup2(old_stdout, int(syscall.Stdout))
 
 	if err != nil {
 		t.Error(err)

--- a/vault_test.go
+++ b/vault_test.go
@@ -60,7 +60,7 @@ func TestVaultFunctions(t *testing.T) {
 
 	key_pw_test, err := vault.GetPasswordPrompt()
 
-	syscall.Dup2(old_stdin,  int(syscall.Stdin))
+	syscall.Dup2(old_stdin, int(syscall.Stdin))
 	syscall.Dup2(old_stdout, int(syscall.Stdout))
 
 	if err != nil {

--- a/vault_test.go
+++ b/vault_test.go
@@ -8,11 +8,22 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
+	"syscall"
 	"testing"
+	"time"
 
+	"github.com/kr/pty"
 	"github.com/ssh-vault/crypto"
 	"github.com/ssh-vault/crypto/aead"
 )
+
+// zomg this is a race condition
+func PtyWriteback(pty *os.File, msg string) {
+	time.Sleep(500 * time.Millisecond)
+	defer pty.Sync()
+	pty.Write([]byte(msg))
+}
 
 // These are done in one function to avoid declaring global variables in a test
 // file.
@@ -28,6 +39,32 @@ func TestVaultFunctions(t *testing.T) {
 	vault, err := New("test_data/id_rsa.pub", "", "create", tmpfile)
 	if err != nil {
 		t.Error(err)
+	}
+
+	key_pw := string("argle-bargle\n")
+	pty, tty, err := pty.Open()
+	if err != nil {
+		t.Errorf("Unable to open pty: %s", err)
+	}
+
+	// File Descriptor magic. GetPasswordPrompt() reads the password
+	// from stdin. For the test, we save stdin to a spare FD,
+	// point stdin at the file, run the system under test, and
+	// finally restore the original stdin
+	old_stdin, _ := syscall.Dup(int(syscall.Stdin))
+	syscall.Dup2(int(tty.Fd()), int(syscall.Stdin))
+
+	go PtyWriteback(pty, key_pw)
+
+	key_pw_test, err := vault.GetPasswordPrompt()
+
+	syscall.Dup2(old_stdin, int(syscall.Stdin))
+
+	if err != nil {
+		t.Error(err)
+	}
+	if string(strings.Trim(key_pw, "\n")) != string(key_pw_test) {
+		t.Errorf("password prompt: expected %s, got %s\n", key_pw, key_pw_test)
 	}
 
 	if err = vault.PKCS8(); err != nil {


### PR DESCRIPTION
@nbari - Thank you so much for this utility. I can probably provide some help with #2, but the keychain support bugged me more immediately.

Apple distributes a patched version of OpenSSH, which uses the encrypted-on-disk Keychain system to store private key passphrases. This PR adds support for reading a key's passphrase from Keychain. For non-darwin platforms, or if a particular key's passphrase isn't in Keychain, the existing password prompting code is used. I've moved it into `get_password_prompt.go`, but it still uses `golang.org/x/crypto/ssh/terminal` for the actual reading. 

Tests: [The PTY library](https://github.com/kr/pty) I used for `GetPasswordPrompt()` is Unix-specific. It works on macOS, Linux, *BSD, but will die on Windows. Given the lack of win32-specific references in here, I'm guessing that's not a big concern. Thanks @kr for writing something that lets me test a TTY password prompt.

/cc @jamfish