### PR TITLE
Update get_password_darwin.go

### DIFF
--- a/get_password_darwin.go
+++ b/get_password_darwin.go
@@ -25,7 +25,7 @@ func (v *vault) GetPassword() ([]byte, error) {
 	}
 
 	keyPassword, err = keychain.GetGenericPassword("SSH", keyPath, "", "")
-	if err == nil {
+	if err == nil &&  keyPassword != nil {
 		return keyPassword, nil
 	}
 


### PR DESCRIPTION
If item is not found in keychain, GetGenericPassword returns nil, nil (keybase/go-keychain/keychain.go:477)