### PR TITLE
prompt private key password on stderr

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Example:
 Binaries and packages for a variety of platforms are published to Bintray:
 [ ![Download](https://api.bintray.com/packages/nbari/ssh-vault/ssh-vault/images/download.svg) ](https://dl.bintray.com/nbari/ssh-vault/)
 
-To download specific version use URL like https://dl.bintray.com/nbari/ssh-vault/ssh-vault_0.12.4_amd64.deb
+To download a specific version, use URL like https://dl.bintray.com/nbari/ssh-vault/ssh-vault_0.12.4_amd64.deb
 
 To download the latest version:
 
@@ -41,7 +41,7 @@ To download the latest version:
 
 Setup go environment https://golang.org/doc/install
 
-For example using $HOME/go for your workspace
+For example, using $HOME/go for your workspace
 
     $ export GOPATH=$HOME/go
 

--- a/get_password_prompt.go
+++ b/get_password_prompt.go
@@ -2,15 +2,16 @@ package sshvault
 
 import (
 	"fmt"
+	"os"
 	"syscall"
 
 	"golang.org/x/crypto/ssh/terminal"
 )
 
-// GetPasswordPrompt ask for key passoword
+// GetPasswordPrompt ask for key password
 func (v *vault) GetPasswordPrompt() ([]byte, error) {
-	fmt.Printf("Enter the key password (%s)\n", v.key)
-	keyPassword, err := terminal.ReadPassword(int(syscall.Stdin))
+	fmt.Fprintf(os.Stderr, "Enter the key password (%s)\n", v.key)
+	keyPassword, err := terminal.ReadPassword(syscall.Stdin)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- [✓] Have you test the code?
- [✓] Have you check that the existing tests are passing?
- [✓] The destination branch is **develop**?

---

This request is to prompt the private key password on stderr instead of stdout, allowing to pipe the result (i.e.: `ssh-vault view encrypted | tar x`).

Also suggest to fix a few typos and remove a redundant type conversion; feel free to adapt the MR.